### PR TITLE
Lambda expressions

### DIFF
--- a/ella-parser/src/ast.rs
+++ b/ella-parser/src/ast.rs
@@ -32,6 +32,13 @@ pub enum ExprKind {
     },
     /// An unary expression (e.g. `-1`).
     Unary { op: Token, arg: Box<Expr> },
+    /// A lambda expression.
+    Lambda {
+        /// Should always be a [`StmtKind::Lambda`]. Note that this field is only a marker and does not store any data.
+        inner_stmt: Box<Stmt>,
+        params: Vec<String>,
+        body: Vec<Stmt>,
+    },
     /// Error token. Used for error recovery.
     Error,
 }
@@ -76,8 +83,11 @@ pub enum StmtKind {
     ExprStmt(Expr),
     /// Return statement.
     ReturnStmt(Expr),
-    /// Error token. Used for error recovery/
+    /// Error token. Used for error recovery.
     Error,
+    /// A lambda "statement". There are no fields as this is only a marker, stored inside [`ExprKind::Lambda`] for variable resolution.
+    /// This should never be visited in a [`Visitor`].
+    Lambda,
 }
 
 impl StmtKind {

--- a/ella-parser/src/parser/snapshots/ella_parser__parser__expr__tests__lambda-with-params.snap
+++ b/ella-parser/src/parser/snapshots/ella_parser__parser__expr__tests__lambda-with-params.snap
@@ -1,0 +1,17 @@
+---
+source: ella-parser/src/parser/expr.rs
+expression: "expr(\"fn (x) {}\")"
+---
+Expr {
+    kind: Lambda {
+        inner_stmt: Stmt {
+            kind: Lambda,
+            span: 0..9,
+        },
+        params: [
+            "x",
+        ],
+        body: [],
+    },
+    span: 0..9,
+}

--- a/ella-parser/src/parser/snapshots/ella_parser__parser__expr__tests__lambda.snap
+++ b/ella-parser/src/parser/snapshots/ella_parser__parser__expr__tests__lambda.snap
@@ -1,0 +1,15 @@
+---
+source: ella-parser/src/parser/expr.rs
+expression: "expr(\"fn () {}\")"
+---
+Expr {
+    kind: Lambda {
+        inner_stmt: Stmt {
+            kind: Lambda,
+            span: 0..8,
+        },
+        params: [],
+        body: [],
+    },
+    span: 0..8,
+}

--- a/ella-parser/src/parser/stmt.rs
+++ b/ella-parser/src/parser/stmt.rs
@@ -177,7 +177,6 @@ impl<'a> Parser<'a> {
         }
 
         self.expect(Token::OpenBrace);
-
         let mut body = Vec::new();
         if !self.eat(Token::CloseBrace) {
             loop {

--- a/ella-parser/src/visitor.rs
+++ b/ella-parser/src/visitor.rs
@@ -36,6 +36,15 @@ pub fn walk_expr<'ast>(visitor: &mut impl Visitor<'ast>, expr: &'ast Expr) {
             visitor.visit_expr(rhs);
         }
         ExprKind::Unary { op: _, arg } => visitor.visit_expr(arg),
+        ExprKind::Lambda {
+            inner_stmt: _,
+            params: _,
+            body,
+        } => {
+            for stmt in body {
+                visitor.visit_stmt(stmt);
+            }
+        }
         ExprKind::Error => {}
     }
 }
@@ -73,12 +82,13 @@ pub fn walk_stmt<'ast>(visitor: &mut impl Visitor<'ast>, stmt: &'ast Stmt) {
                 visit_stmt_list!(visitor, else_block);
             }
         }
-        StmtKind::WhileStmt { condition, body} => {
+        StmtKind::WhileStmt { condition, body } => {
             visitor.visit_expr(condition);
             visit_stmt_list!(visitor, body);
         }
         StmtKind::ExprStmt(expr) => visitor.visit_expr(expr),
         StmtKind::ReturnStmt(expr) => visitor.visit_expr(expr),
+        StmtKind::Lambda => unreachable!(),
         StmtKind::Error => {}
     }
 }

--- a/ella/tests/integration_tests.rs
+++ b/ella/tests/integration_tests.rs
@@ -269,6 +269,18 @@ mod functions {
                 assert_eq(f(), 100);"#,
             );
         }
+
+        /// IIFE: Immediately invoked function expression
+        #[test]
+        #[should_panic]
+        fn lambda_iife() {
+            interpret(
+                r#"
+                (fn() {
+                    assert(false); // should be called and panic
+                })();"#,
+            );
+        }
     }
 }
 

--- a/ella/tests/integration_tests.rs
+++ b/ella/tests/integration_tests.rs
@@ -236,6 +236,40 @@ mod functions {
             );
         }
     }
+
+    mod lambda_expr {
+        use super::*;
+
+        #[test]
+        fn basic_lambda() {
+            interpret(
+                r#"
+                let f = fn() { return 2; };
+                assert_eq(f(), 2);"#,
+            );
+        }
+
+        #[test]
+        fn basic_lambda_with_param() {
+            interpret(
+                r#"
+                let square = fn(x) { return x * x; };
+                assert_eq(square(10), 100);"#,
+            );
+        }
+
+        #[test]
+        fn lambda_closure() {
+            interpret(
+                r#"
+                fn create_closure(x) {
+                    return fn() { return x * x; };
+                }
+                let f = create_closure(10);
+                assert_eq(f(), 100);"#,
+            );
+        }
+    }
 }
 
 mod control_flow {


### PR DESCRIPTION
New syntax:
```
// basic lambda
let f = fn() {
    // lambda body
    return 0;
};
// params
let g = fn(x) { return x; };
// iife (immediately invoked function expression)
(fn() {
    // lambda body
})();
```